### PR TITLE
Fix cache resizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = { version = "0.2", git = "https://github.com/gfx-rs/wgpu-rs", rev = "a4ad7ae6ff2fc42396b802968dcc95bbf0612235" }
+wgpu = { version = "0.2", git = "https://github.com/gfx-rs/wgpu-rs", rev = "a05eab15a1efeb9c5ac49c0b4bd2620bcf850a3a" }
 glyph_brush = "0.5"
 log = "0.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
     ) -> Result<(), String> {
-        let mut cache = self.pipeline.cache();
+        let pipeline = &mut self.pipeline;
 
         let mut brush_action;
 
@@ -192,7 +192,8 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                     let offset = [rect.min.x as u16, rect.min.y as u16];
                     let size = [rect.width() as u16, rect.height() as u16];
 
-                    cache.update(device, encoder, offset, size, tex_data);
+                    pipeline
+                        .update_cache(device, encoder, offset, size, tex_data);
                 },
                 Instance::from,
             );
@@ -227,10 +228,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                         );
                     }
 
-                    cache = self
-                        .pipeline
-                        .increase_cache_size(device, new_width, new_height);
-
+                    pipeline.increase_cache_size(device, new_width, new_height);
                     self.glyph_brush.resize_texture(new_width, new_height);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [`wgpu`]: https://github.com/gfx-rs/wgpu
 //! [`glyph_brush`]: https://github.com/alexheretic/glyph-brush/tree/master/glyph-brush
+#![deny(unused_results)]
 mod builder;
 mod pipeline;
 
@@ -226,11 +227,11 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                         );
                     }
 
-                    self.pipeline
+                    cache = self
+                        .pipeline
                         .increase_cache_size(device, new_width, new_height);
-                    self.glyph_brush.resize_texture(new_width, new_height);
 
-                    cache = self.pipeline.cache();
+                    self.glyph_brush.resize_texture(new_width, new_height);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
     ) -> Result<(), String> {
-        let cache = self.pipeline.cache();
+        let mut cache = self.pipeline.cache();
 
         let mut brush_action;
 
@@ -229,6 +229,8 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                     self.pipeline
                         .increase_cache_size(device, new_width, new_height);
                     self.glyph_brush.resize_texture(new_width, new_height);
+
+                    cache = self.pipeline.cache();
                 }
             }
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -194,7 +194,7 @@ impl Pipeline {
         device: &wgpu::Device,
         width: u32,
         height: u32,
-    ) {
+    ) -> Rc<Cache> {
         self.cache = Rc::new(Cache::new(device, width, height));
 
         self.uniforms = Self::create_uniforms(
@@ -204,6 +204,8 @@ impl Pipeline {
             &self.sampler,
             &self.cache.view,
         );
+
+        self.cache.clone()
     }
 
     pub fn upload(

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,16 +1,14 @@
 mod cache;
 
-pub use cache::Cache;
-
-use std::mem;
-use std::rc::Rc;
+use cache::Cache;
 
 use glyph_brush::rusttype::{point, Rect};
+use std::mem;
 
 pub struct Pipeline {
     transform: wgpu::Buffer,
     sampler: wgpu::Sampler,
-    cache: Rc<Cache>,
+    cache: Cache,
     uniform_layout: wgpu::BindGroupLayout,
     uniforms: wgpu::BindGroup,
     pipeline: wgpu::RenderPipeline,
@@ -174,7 +172,7 @@ impl Pipeline {
         Pipeline {
             transform,
             sampler,
-            cache: Rc::new(cache),
+            cache,
             uniform_layout,
             uniforms,
             pipeline,
@@ -185,8 +183,15 @@ impl Pipeline {
         }
     }
 
-    pub fn cache(&self) -> Rc<Cache> {
-        self.cache.clone()
+    pub fn update_cache(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        offset: [u16; 2],
+        size: [u16; 2],
+        data: &[u8],
+    ) {
+        self.cache.update(device, encoder, offset, size, data);
     }
 
     pub fn increase_cache_size(
@@ -194,8 +199,8 @@ impl Pipeline {
         device: &wgpu::Device,
         width: u32,
         height: u32,
-    ) -> Rc<Cache> {
-        self.cache = Rc::new(Cache::new(device, width, height));
+    ) {
+        self.cache = Cache::new(device, width, height);
 
         self.uniforms = Self::create_uniforms(
             device,
@@ -204,8 +209,6 @@ impl Pipeline {
             &self.sampler,
             &self.cache.view,
         );
-
-        self.cache.clone()
     }
 
     pub fn upload(


### PR DESCRIPTION
Fixes #7 and fixes #8.

This was quite a silly bug :sweat_smile: Basically, we were updating the old cache instead of the new one when a resize happened.

I have improved the internal API safety. Now, the `Cache` type does not leak outside `Pipeline`. Therefore, all mutations to it need to go through the `Cache` owner.

@rukai, let me know if the fix works for you!