### PR TITLE
Implement From<glyph_brush::GlyphBrushBuilder> for wgpu_glyph::GlyphBrushBuilder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -13,6 +13,16 @@ pub struct GlyphBrushBuilder<'a, D, H = DefaultSectionHasher> {
     depth: D,
 }
 
+impl<'a, H> From<glyph_brush::GlyphBrushBuilder<'a, H>> for GlyphBrushBuilder<'a, (), H> {
+    fn from(inner: glyph_brush::GlyphBrushBuilder<'a, H>) -> Self {
+        GlyphBrushBuilder {
+            inner,
+            texture_filter_method: wgpu::FilterMode::Linear,
+            depth: (),
+        }
+    }
+}
+
 impl<'a> GlyphBrushBuilder<'a, ()> {
     /// Specifies the default font data used to render glyphs.
     /// Referenced with `FontId(0)`, which is default.


### PR DESCRIPTION
This makes it easier to write code for loading fonts into glyphbrush without needing to worry about which library is responsible for drawing them.