### PR TITLE
Update all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = { version = "0.3", git = "https://github.com/gfx-rs/wgpu-rs", rev = "cb25914b95b58fee0dc139b400867e7a731d98f4" }
-glyph_brush = "0.5"
+wgpu = { version = "0.3", git = "https://github.com/gfx-rs/wgpu-rs", rev = "012d08d64de924da93289c2b51fb06b22d7348cf" }
+glyph_brush = "0.6"
 log = "0.4"
 
 [dev-dependencies]
-env_logger = "0.6"
-winit = "0.20.0-alpha3"
-raw-window-handle = "0.1"
+env_logger = "0.7"
+winit = "0.20.0-alpha4"
+raw-window-handle = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,8 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, (), H> {
         render_format: wgpu::TextureFormat,
         raw_builder: glyph_brush::GlyphBrushBuilder<'font, H>,
     ) -> Self {
-        let (cache_width, cache_height) = raw_builder.initial_cache_size;
-
+        let glyph_brush = raw_builder.build();
+        let (cache_width, cache_height) = glyph_brush.texture_dimensions();
         GlyphBrush {
             pipeline: Pipeline::<()>::new(
                 device,
@@ -202,7 +202,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, (), H> {
                 cache_width,
                 cache_height,
             ),
-            glyph_brush: raw_builder.build(),
+            glyph_brush,
         }
     }
 
@@ -269,8 +269,8 @@ impl<'font, H: BuildHasher>
         depth_stencil_state: wgpu::DepthStencilStateDescriptor,
         raw_builder: glyph_brush::GlyphBrushBuilder<'font, H>,
     ) -> Self {
-        let (cache_width, cache_height) = raw_builder.initial_cache_size;
-
+        let glyph_brush = raw_builder.build();
+        let (cache_width, cache_height) = glyph_brush.texture_dimensions();
         GlyphBrush {
             pipeline: Pipeline::<wgpu::DepthStencilStateDescriptor>::new(
                 device,
@@ -280,7 +280,7 @@ impl<'font, H: BuildHasher>
                 cache_width,
                 cache_height,
             ),
-            glyph_brush: raw_builder.build(),
+            glyph_brush,
         }
     }
 


### PR DESCRIPTION
Updates to the latest wgpu commit giving us access to the latest winit release.

Looks like glyph_brush requires getting texture_dimensions() from the built glyph_brush as initial_cache_size is no longer available. https://github.com/alexheretic/glyph-brush/blob/master/glyph-brush/CHANGELOG.md