### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0]
+### Added
+- `From<glyph_brush::GlyphBrushBuilder>` implementation for `wgpu_glyph::GlyphBrushBuilder`. [#19]
+
+### Changed
+- `wgpu` dependency updated to `0.4`.
+- `glyph-brush` dependency updated to `0.6`.
+
 
 ## [0.4.0]
 ### Added
@@ -59,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release! :tada:
 
 
-[Unreleased]: https://github.com/hecrj/wgpu_glyph/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/hecrj/wgpu_glyph/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/hecrj/wgpu_glyph/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/hecrj/wgpu_glyph/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/hecrj/wgpu_glyph/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/hecrj/wgpu_glyph/compare/0.2.0...0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `From<glyph_brush::GlyphBrushBuilder>` implementation for `wgpu_glyph::GlyphBrushBuilder`. [#19]
 
 ### Changed
-- `wgpu` dependency updated to `0.4`.
-- `glyph-brush` dependency updated to `0.6`.
+- `glyph-brush` dependency updated to `0.6`. [#21]
+- `wgpu` dependency updated to `0.4`. [#24]
 
+
+[#19]: https://github.com/hecrj/wgpu_glyph/pull/19
+[#21]: https://github.com/hecrj/wgpu_glyph/pull/21
+[#24]: https://github.com/hecrj/wgpu_glyph/pull/24
 
 ## [0.4.0]
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu_glyph"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2018"
 description = "A fast text renderer for wgpu, powered by glyph_brush"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = { version = "0.3", git = "https://github.com/gfx-rs/wgpu-rs", rev = "012d08d64de924da93289c2b51fb06b22d7348cf" }
+wgpu = "0.4"
 glyph_brush = "0.6"
 log = "0.4"
 


### PR DESCRIPTION
Fixes #22. 

This PR prepares the `0.5.0` release, using the new releases of `wgpu 0.4` and `glyph-brush 0.6`.