### PR TITLE
Use immutable device ref when building GlyphBrush

### DIFF
--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), String> {
     // Prepare glyph_brush
     let inconsolata: &[u8] = include_bytes!("Inconsolata-Regular.ttf");
     let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(inconsolata)
-        .build(&mut device, render_format);
+        .build(&device, render_format);
 
     // Render loop
     window.request_redraw();

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), String> {
             stencil_read_mask: 0,
             stencil_write_mask: 0,
         })
-        .build(&mut device, FORMAT);
+        .build(&device, FORMAT);
 
     // Render loop
     window.request_redraw();

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), String> {
     // Prepare glyph_brush
     let inconsolata: &[u8] = include_bytes!("Inconsolata-Regular.ttf");
     let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(inconsolata)
-        .build(&mut device, render_format);
+        .build(&device, render_format);
 
     // Render loop
     window.request_redraw();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -110,7 +110,7 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, (), H> {
     /// text for texture views with the given `render_format`.
     pub fn build(
         self,
-        device: &mut wgpu::Device,
+        device: &wgpu::Device,
         render_format: wgpu::TextureFormat,
     ) -> GlyphBrush<'a, (), H> {
         GlyphBrush::<(), H>::new(
@@ -129,7 +129,7 @@ impl<'a, H: BuildHasher>
     /// text for texture views with the given `render_format`.
     pub fn build(
         self,
-        device: &mut wgpu::Device,
+        device: &wgpu::Device,
         render_format: wgpu::TextureFormat,
     ) -> GlyphBrush<'a, wgpu::DepthStencilStateDescriptor, H> {
         GlyphBrush::<wgpu::DepthStencilStateDescriptor, H>::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<'font, Depth, H: BuildHasher> GlyphBrush<'font, Depth, H> {
 
 impl<'font, H: BuildHasher> GlyphBrush<'font, (), H> {
     fn new(
-        device: &mut wgpu::Device,
+        device: &wgpu::Device,
         filter_mode: wgpu::FilterMode,
         render_format: wgpu::TextureFormat,
         raw_builder: glyph_brush::GlyphBrushBuilder<'font, H>,
@@ -310,7 +310,7 @@ impl<'font, H: BuildHasher>
     GlyphBrush<'font, wgpu::DepthStencilStateDescriptor, H>
 {
     fn new(
-        device: &mut wgpu::Device,
+        device: &wgpu::Device,
         filter_mode: wgpu::FilterMode,
         render_format: wgpu::TextureFormat,
         depth_stencil_state: wgpu::DepthStencilStateDescriptor,


### PR DESCRIPTION
In `wgpu` it seems like pipeline setup methods generally accept the `wgpu::Device` by immutable reference.  It works fine this way (`Pipeline::new` only requires an immutable reference), so I updated the API for creating a `GlyphBrush` to reflect that.