### PR TITLE
Force cargo to install winit-0.20.0-alpha4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ log = "0.4"
 
 [dev-dependencies]
 env_logger = "0.7"
-winit = "0.20.0-alpha4"
+winit = "=0.20.0-alpha4"
 raw-window-handle = "0.3"


### PR DESCRIPTION
The original semver specification `winit = "0.20.0-alpha4"` allows cargo to install `0.20.0`, which generates a bunch of errors:

```
error[E0599]: no method named `to_physical` found for type `winit::dpi::PhysicalSize<u32>` in the current scope
  --> examples\hello.rs:33:40
   |
33 |     let mut size = window.inner_size().to_physical(window.hidpi_factor());
   |                                        ^^^^^^^^^^^ method not found in `winit::dpi::PhysicalSize<u32>`

error[E0599]: no method named `hidpi_factor` found for type `winit::window::Window` in the current scope
  --> examples\hello.rs:33:59
   |
33 |     let mut size = window.inner_size().to_physical(window.hidpi_factor());
   |                                                           ^^^^^^^^^^^^ method not found in `winit::window::Window`

error[E0599]: no variant or associated item named `RedrawRequested` found for type `winit::event::WindowEvent<'_>` in the current scope
  --> examples\hello.rs:78:51
   |
78 |                 event: winit::event::WindowEvent::RedrawRequested,
   |                                                   ^^^^^^^^^^^^^^^ variant or associated item not found in `winit::event::WindowEvent<'_>`

error[E0599]: no method named `to_physical` found for type `winit::dpi::PhysicalSize<u32>` in the current scope
  --> examples\hello.rs:64:33
   |
64 |                 size = new_size.to_physical(window.hidpi_factor());
   |                                 ^^^^^^^^^^^ method not found in `winit::dpi::PhysicalSize<u32>`

error[E0599]: no method named `hidpi_factor` found for type `winit::window::Window` in the current scope
  --> examples\hello.rs:64:52
   |
64 |                 size = new_size.to_physical(window.hidpi_factor());
   |                                                    ^^^^^^^^^^^^ method not found in `winit::window::Window`

error: aborting due to 5 previous errors

For more information about this error, try `rustc --explain E0599`.
error: could not compile `wgpu_glyph`.
```

These functions are only available in `0.20.0-alpha4` but not in `0.20.0`.