### PR TITLE
Update `glyph_brush` to `0.7`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 wgpu = "0.5"
-glyph_brush = "0.6"
+glyph_brush = "0.7"
 log = "0.4"
 zerocopy = "0.3"
 

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,6 +1,7 @@
-use wgpu_glyph::{GlyphBrushBuilder, Region, Scale, Section};
+use std::error::Error;
+use wgpu_glyph::{ab_glyph, GlyphBrushBuilder, Region, Section, Text};
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     // Open window and create a surface
@@ -51,9 +52,11 @@ fn main() -> Result<(), String> {
     );
 
     // Prepare glyph_brush
-    let inconsolata: &[u8] = include_bytes!("Inconsolata-Regular.ttf");
-    let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(inconsolata)
-        .expect("Load font")
+    let inconsolata = ab_glyph::FontArc::try_from_slice(include_bytes!(
+        "Inconsolata-Regular.ttf"
+    ))?;
+
+    let mut glyph_brush = GlyphBrushBuilder::using_font(inconsolata)
         .build(&device, render_format);
 
     // Render loop
@@ -118,11 +121,12 @@ fn main() -> Result<(), String> {
                 }
 
                 glyph_brush.queue(Section {
-                    text: "Hello wgpu_glyph!",
                     screen_position: (30.0, 30.0),
-                    color: [0.0, 0.0, 0.0, 1.0],
-                    scale: Scale { x: 40.0, y: 40.0 },
                     bounds: (size.width as f32, size.height as f32),
+                    text: vec![Text::default()
+                        .with_text("Hello wgpu_glyph!")
+                        .with_color([0.0, 0.0, 0.0, 1.0])
+                        .with_scale(40.0)],
                     ..Section::default()
                 });
 
@@ -138,11 +142,12 @@ fn main() -> Result<(), String> {
                     .expect("Draw queued");
 
                 glyph_brush.queue(Section {
-                    text: "Hello wgpu_glyph!",
                     screen_position: (30.0, 90.0),
-                    color: [1.0, 1.0, 1.0, 1.0],
-                    scale: Scale { x: 40.0, y: 40.0 },
                     bounds: (size.width as f32, size.height as f32),
+                    text: vec![Text::default()
+                        .with_text("Hello wgpu_glyph!")
+                        .with_color([1.0, 1.0, 1.0, 1.0])
+                        .with_scale(40.0)],
                     ..Section::default()
                 });
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,7 @@
-use wgpu_glyph::{GlyphBrushBuilder, Scale, Section};
+use std::error::Error;
+use wgpu_glyph::{ab_glyph, GlyphBrushBuilder, Section, Text};
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     // Open window and create a surface
@@ -51,9 +52,11 @@ fn main() -> Result<(), String> {
     );
 
     // Prepare glyph_brush
-    let inconsolata: &[u8] = include_bytes!("Inconsolata-Regular.ttf");
-    let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(inconsolata)
-        .expect("Load fonts")
+    let inconsolata = ab_glyph::FontArc::try_from_slice(include_bytes!(
+        "Inconsolata-Regular.ttf"
+    ))?;
+
+    let mut glyph_brush = GlyphBrushBuilder::using_font(inconsolata)
         .build(&device, render_format);
 
     // Render loop
@@ -118,20 +121,22 @@ fn main() -> Result<(), String> {
                 }
 
                 glyph_brush.queue(Section {
-                    text: "Hello wgpu_glyph!",
                     screen_position: (30.0, 30.0),
-                    color: [0.0, 0.0, 0.0, 1.0],
-                    scale: Scale { x: 40.0, y: 40.0 },
                     bounds: (size.width as f32, size.height as f32),
+                    text: vec![Text::default()
+                        .with_text("Hello wgpu_glyph!")
+                        .with_color([0.0, 0.0, 0.0, 1.0])
+                        .with_scale(40.0)],
                     ..Section::default()
                 });
 
                 glyph_brush.queue(Section {
-                    text: "Hello wgpu_glyph!",
                     screen_position: (30.0, 90.0),
-                    color: [1.0, 1.0, 1.0, 1.0],
-                    scale: Scale { x: 40.0, y: 40.0 },
                     bounds: (size.width as f32, size.height as f32),
+                    text: vec![Text::default()
+                        .with_text("Hello wgpu_glyph!")
+                        .with_color([1.0, 1.0, 1.0, 1.0])
+                        .with_scale(40.0)],
                     ..Section::default()
                 });
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -50,6 +50,8 @@ impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
     ///
     /// Significantly reduces worst case latency in multicore environments.
     ///
+    /// By default, this feature is __enabled__.
+    ///
     /// # Platform-specific behaviour
     ///
     /// This option has no effect on wasm32.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,6 +45,21 @@ impl GlyphBrushBuilder<(), ()> {
 impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
     delegate_glyph_brush_builder_fns!(inner);
 
+    /// When multiple CPU cores are available spread rasterization work across
+    /// all cores.
+    ///
+    /// Significantly reduces worst case latency in multicore environments.
+    ///
+    /// # Platform-specific behaviour
+    ///
+    /// This option has no effect on wasm32.
+    pub fn draw_cache_multithread(mut self, multithread: bool) -> Self {
+        self.inner.draw_cache_builder =
+            self.inner.draw_cache_builder.multithread(multithread);
+
+        self
+    }
+
     /// Sets the texture filtering method.
     pub fn texture_filter_method(
         mut self,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,22 +1,22 @@
 use core::hash::BuildHasher;
 
+use glyph_brush::ab_glyph::Font;
 use glyph_brush::delegate_glyph_brush_builder_fns;
-use glyph_brush::{rusttype, DefaultSectionHasher};
-use rusttype::{Error, Font, SharedBytes};
+use glyph_brush::DefaultSectionHasher;
 
 use super::GlyphBrush;
 
 /// Builder for a [`GlyphBrush`](struct.GlyphBrush.html).
-pub struct GlyphBrushBuilder<'a, D, H = DefaultSectionHasher> {
-    inner: glyph_brush::GlyphBrushBuilder<'a, H>,
+pub struct GlyphBrushBuilder<D, F, H = DefaultSectionHasher> {
+    inner: glyph_brush::GlyphBrushBuilder<F, H>,
     texture_filter_method: wgpu::FilterMode,
     depth: D,
 }
 
-impl<'a, H> From<glyph_brush::GlyphBrushBuilder<'a, H>>
-    for GlyphBrushBuilder<'a, (), H>
+impl<F, H> From<glyph_brush::GlyphBrushBuilder<F, H>>
+    for GlyphBrushBuilder<(), F, H>
 {
-    fn from(inner: glyph_brush::GlyphBrushBuilder<'a, H>) -> Self {
+    fn from(inner: glyph_brush::GlyphBrushBuilder<F, H>) -> Self {
         GlyphBrushBuilder {
             inner,
             texture_filter_method: wgpu::FilterMode::Linear,
@@ -25,41 +25,15 @@ impl<'a, H> From<glyph_brush::GlyphBrushBuilder<'a, H>>
     }
 }
 
-impl<'a> GlyphBrushBuilder<'a, ()> {
-    /// Specifies the default font data used to render glyphs.
-    /// Referenced with `FontId(0)`, which is default.
-    #[inline]
-    pub fn using_font_bytes<B: Into<SharedBytes<'a>>>(
-        font_0_data: B,
-    ) -> Result<Self, Error> {
-        let font = Font::from_bytes(font_0_data)?;
-
-        Ok(Self::using_font(font))
-    }
-
-    #[inline]
-    pub fn using_fonts_bytes<B, V>(font_data: V) -> Result<Self, Error>
-    where
-        B: Into<SharedBytes<'a>>,
-        V: Into<Vec<B>>,
-    {
-        let fonts = font_data
-            .into()
-            .into_iter()
-            .map(Font::from_bytes)
-            .collect::<Result<Vec<Font>, Error>>()?;
-
-        Ok(Self::using_fonts(fonts))
-    }
-
+impl GlyphBrushBuilder<(), ()> {
     /// Specifies the default font used to render glyphs.
     /// Referenced with `FontId(0)`, which is default.
     #[inline]
-    pub fn using_font(font_0: Font<'a>) -> Self {
-        Self::using_fonts(vec![font_0])
+    pub fn using_font<F: Font>(font: F) -> GlyphBrushBuilder<(), F> {
+        Self::using_fonts(vec![font])
     }
 
-    pub fn using_fonts<V: Into<Vec<Font<'a>>>>(fonts: V) -> Self {
+    pub fn using_fonts<F: Font>(fonts: Vec<F>) -> GlyphBrushBuilder<(), F> {
         GlyphBrushBuilder {
             inner: glyph_brush::GlyphBrushBuilder::using_fonts(fonts),
             texture_filter_method: wgpu::FilterMode::Linear,
@@ -68,7 +42,7 @@ impl<'a> GlyphBrushBuilder<'a, ()> {
     }
 }
 
-impl<'a, D, H: BuildHasher> GlyphBrushBuilder<'a, D, H> {
+impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
     delegate_glyph_brush_builder_fns!(inner);
 
     /// Sets the texture filtering method.
@@ -90,7 +64,7 @@ impl<'a, D, H: BuildHasher> GlyphBrushBuilder<'a, D, H> {
     pub fn section_hasher<T: BuildHasher>(
         self,
         section_hasher: T,
-    ) -> GlyphBrushBuilder<'a, D, T> {
+    ) -> GlyphBrushBuilder<D, F, T> {
         GlyphBrushBuilder {
             inner: self.inner.section_hasher(section_hasher),
             texture_filter_method: self.texture_filter_method,
@@ -102,7 +76,7 @@ impl<'a, D, H: BuildHasher> GlyphBrushBuilder<'a, D, H> {
     pub fn depth_stencil_state(
         self,
         depth_stencil_state: wgpu::DepthStencilStateDescriptor,
-    ) -> GlyphBrushBuilder<'a, wgpu::DepthStencilStateDescriptor, H> {
+    ) -> GlyphBrushBuilder<wgpu::DepthStencilStateDescriptor, F, H> {
         GlyphBrushBuilder {
             inner: self.inner,
             texture_filter_method: self.texture_filter_method,
@@ -111,15 +85,15 @@ impl<'a, D, H: BuildHasher> GlyphBrushBuilder<'a, D, H> {
     }
 }
 
-impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, (), H> {
+impl<F: Font + Sync, H: BuildHasher> GlyphBrushBuilder<(), F, H> {
     /// Builds a `GlyphBrush` using the given `wgpu::Device` that can render
     /// text for texture views with the given `render_format`.
     pub fn build(
         self,
         device: &wgpu::Device,
         render_format: wgpu::TextureFormat,
-    ) -> GlyphBrush<'a, (), H> {
-        GlyphBrush::<(), H>::new(
+    ) -> GlyphBrush<(), F, H> {
+        GlyphBrush::<(), F, H>::new(
             device,
             self.texture_filter_method,
             render_format,
@@ -128,8 +102,8 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, (), H> {
     }
 }
 
-impl<'a, H: BuildHasher>
-    GlyphBrushBuilder<'a, wgpu::DepthStencilStateDescriptor, H>
+impl<F: Font + Sync, H: BuildHasher>
+    GlyphBrushBuilder<wgpu::DepthStencilStateDescriptor, F, H>
 {
     /// Builds a `GlyphBrush` using the given `wgpu::Device` that can render
     /// text for texture views with the given `render_format`.
@@ -137,8 +111,8 @@ impl<'a, H: BuildHasher>
         self,
         device: &wgpu::Device,
         render_format: wgpu::TextureFormat,
-    ) -> GlyphBrush<'a, wgpu::DepthStencilStateDescriptor, H> {
-        GlyphBrush::<wgpu::DepthStencilStateDescriptor, H>::new(
+    ) -> GlyphBrush<wgpu::DepthStencilStateDescriptor, F, H> {
+        GlyphBrush::<wgpu::DepthStencilStateDescriptor, F, H>::new(
             device,
             self.texture_filter_method,
             render_format,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use log::{log_enabled, warn};
 /// glyph draw caching & efficient GPU texture cache updating and re-sizing on demand.
 ///
 /// Build using a [`GlyphBrushBuilder`](struct.GlyphBrushBuilder.html).
-pub struct GlyphBrush<Depth, F, H = DefaultSectionHasher> {
+pub struct GlyphBrush<Depth, F = ab_glyph::FontArc, H = DefaultSectionHasher> {
     pipeline: Pipeline<Depth>,
     glyph_brush: glyph_brush::GlyphBrush<Instance, Extra, F, H>,
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,7 +3,7 @@ mod cache;
 use crate::Region;
 use cache::Cache;
 
-use glyph_brush::rusttype::{point, Rect};
+use glyph_brush::ab_glyph::{point, Rect};
 use std::marker::PhantomData;
 use std::mem;
 use zerocopy::AsBytes;
@@ -442,19 +442,15 @@ pub struct Instance {
 
 impl Instance {
     const INITIAL_AMOUNT: usize = 50_000;
-}
 
-impl From<glyph_brush::GlyphVertex> for Instance {
-    #[inline]
-    fn from(vertex: glyph_brush::GlyphVertex) -> Instance {
-        let glyph_brush::GlyphVertex {
+    pub fn from_vertex(
+        glyph_brush::GlyphVertex {
             mut tex_coords,
             pixel_coords,
             bounds,
-            color,
-            z,
-        } = vertex;
-
+            extra,
+        }: glyph_brush::GlyphVertex,
+    ) -> Instance {
         let gl_bounds = bounds;
 
         let mut gl_rect = Rect {
@@ -492,11 +488,11 @@ impl From<glyph_brush::GlyphVertex> for Instance {
         }
 
         Instance {
-            left_top: [gl_rect.min.x, gl_rect.max.y, z],
+            left_top: [gl_rect.min.x, gl_rect.max.y, extra.z],
             right_bottom: [gl_rect.max.x, gl_rect.min.y],
             tex_left_top: [tex_coords.min.x, tex_coords.max.y],
             tex_right_bottom: [tex_coords.max.x, tex_coords.min.y],
-            color,
+            color: extra.color,
         }
     }
 }


### PR DESCRIPTION
This PR updates `glyph_brush` to [the latest release](https://github.com/alexheretic/glyph-brush/releases/tag/glyph-brush-0.7).

These are the minimum changes to keep the examples working as before. There may be new API methods that we need to expose.

Let me know if you find anything amiss.

Fixes #42. Fixes #37.