### PR TITLE
Use `StagingBelt` for uploading data

### DIFF
--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -38,6 +38,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             .expect("Request device")
     });
 
+    // Create staging belt and a local pool
+    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
+    let mut local_pool = futures::executor::LocalPool::new();
+    let local_spawner = local_pool.spawner();
+
     // Prepare swap chain
     let render_format = wgpu::TextureFormat::Bgra8UnormSrgb;
     let mut size = window.inner_size();
@@ -140,6 +145,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
+                        &mut staging_belt,
                         &mut encoder,
                         &frame.view,
                         size.width,
@@ -160,6 +166,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued_with_transform_and_scissoring(
                         &device,
+                        &mut staging_belt,
                         &mut encoder,
                         &frame.view,
                         wgpu_glyph::orthographic_projection(
@@ -175,7 +182,18 @@ fn main() -> Result<(), Box<dyn Error>> {
                     )
                     .expect("Draw queued");
 
+                // Submit the work!
+                staging_belt.finish();
                 queue.submit(Some(encoder.finish()));
+
+                // Recall unused staging buffers
+                use futures::task::SpawnExt;
+
+                local_spawner
+                    .spawn(staging_belt.recall())
+                    .expect("Recall staging belt");
+
+                local_pool.run_until_stalled();
             }
             _ => {
                 *control_flow = winit::event_loop::ControlFlow::Wait;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -38,6 +38,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             .expect("Request device")
     });
 
+    // Create staging belt and a local pool
+    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
+    let mut local_pool = futures::executor::LocalPool::new();
+    let local_spawner = local_pool.spawner();
+
     // Prepare swap chain
     let render_format = wgpu::TextureFormat::Bgra8UnormSrgb;
     let mut size = window.inner_size();
@@ -149,6 +154,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
+                        &mut staging_belt,
                         &mut encoder,
                         &frame.view,
                         size.width,
@@ -156,7 +162,18 @@ fn main() -> Result<(), Box<dyn Error>> {
                     )
                     .expect("Draw queued");
 
+                // Submit the work!
+                staging_belt.finish();
                 queue.submit(Some(encoder.finish()));
+
+                // Recall unused staging buffers
+                use futures::task::SpawnExt;
+
+                local_spawner
+                    .spawn(staging_belt.recall())
+                    .expect("Recall staging belt");
+
+                local_pool.run_until_stalled();
             }
             _ => {
                 *control_flow = winit::event_loop::ControlFlow::Wait;

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -1,11 +1,16 @@
-use wgpu::util::DeviceExt;
+use core::num::NonZeroU64;
 
 pub struct Cache {
     texture: wgpu::Texture,
     pub(super) view: wgpu::TextureView,
+    upload_buffer: wgpu::Buffer,
+    upload_buffer_size: u64,
 }
 
 impl Cache {
+    const INITIAL_UPLOAD_BUFFER_SIZE: u64 =
+        wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as u64 * 100;
+
     pub fn new(device: &wgpu::Device, width: u32, height: u32) -> Cache {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("wgpu_glyph::Cache"),
@@ -23,12 +28,25 @@ impl Cache {
 
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        Cache { texture, view }
+        let upload_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("wgpu_glyph::Cache upload buffer"),
+            size: Self::INITIAL_UPLOAD_BUFFER_SIZE,
+            usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        Cache {
+            texture,
+            view,
+            upload_buffer,
+            upload_buffer_size: Self::INITIAL_UPLOAD_BUFFER_SIZE,
+        }
     }
 
     pub fn update(
-        &self,
+        &mut self,
         device: &wgpu::Device,
+        staging_belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         offset: [u16; 2],
         size: [u16; 2],
@@ -45,21 +63,36 @@ impl Cache {
         let padded_width_padding = (align - width % align) % align;
         let padded_width = width + padded_width_padding;
 
-        let mut padded_data = vec![0; padded_width * height];
+        let padded_data_size = (padded_width * height) as u64;
+
+        if self.upload_buffer_size < padded_data_size {
+            self.upload_buffer =
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("wgpu_glyph::Cache upload buffer"),
+                    size: padded_data_size,
+                    usage: wgpu::BufferUsage::COPY_SRC,
+                    mapped_at_creation: false,
+                });
+
+            self.upload_buffer_size = padded_data_size;
+        }
+
+        let mut padded_data = staging_belt.write_buffer(
+            encoder,
+            &self.upload_buffer,
+            0,
+            NonZeroU64::new(padded_data_size).unwrap(),
+            device,
+        );
+
         for row in 0..height {
             padded_data[row * padded_width..row * padded_width + width]
                 .copy_from_slice(&data[row * width..(row + 1) * width])
         }
-        let buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: None,
-                contents: &padded_data,
-                usage: wgpu::BufferUsage::COPY_SRC,
-            });
 
         encoder.copy_buffer_to_texture(
             wgpu::BufferCopyView {
-                buffer: &buffer,
+                buffer: &self.upload_buffer,
                 layout: wgpu::TextureDataLayout {
                     offset: 0,
                     bytes_per_row: padded_width as u32,


### PR DESCRIPTION
Instead of reallocating staging buffers every frame, we ask the user to provide a staging belt of buffers.

@rukai @dhardy Does this seem like a good idea to you?