### PR TITLE
Replace `zerocopy` with `bytemuck`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated `wgpu` to `0.7`. [#50]
+- Replaced `zerocopy` with `bytemuck`. [#51]
 
 [#50]: https://github.com/hecrj/wgpu_glyph/pull/50
+[#51]: https://github.com/hecrj/wgpu_glyph/pull/51
 
 
 ## [0.10.0] - 2020-08-27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ readme = "README.md"
 wgpu = "0.7"
 glyph_brush = "0.7"
 log = "0.4"
-zerocopy = "0.3"
+
+[dependencies.bytemuck]
+version = "1.4"
+features = ["derive"]
 
 [dev-dependencies]
 env_logger = "0.7"


### PR DESCRIPTION
Depends on #50.

Replaces `zerocopy` with `bytemuck`, which should reduce compilation time.