### PR TITLE
Update `winit` to `0.24`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ features = ["derive"]
 
 [dev-dependencies]
 env_logger = "0.7"
-winit = "0.22"
+winit = "0.24"
 futures = "0.3"


### PR DESCRIPTION
Depends on #51.

Updates the `winit` dev-dependency to the latest release.