### PR TITLE
Fix stale section_hasher doc default hasher comment

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -77,7 +77,7 @@ impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
     /// This hasher is used to distinguish sections, rather than for hashmap
     /// internal use.
     ///
-    /// Defaults to [seahash](https://docs.rs/seahash).
+    /// Defaults to [xxHash](https://docs.rs/twox-hash).
     pub fn section_hasher<T: BuildHasher>(
         self,
         section_hasher: T,


### PR DESCRIPTION
glyph_brush switched from seahash to xxhash in 0.4.1 https://github.com/alexheretic/glyph-brush/blob/efd4f76923bdbcfe0929a1fa757bd60d5ee52db0/glyph-brush/CHANGELOG.md#041

See [here](https://github.com/alexheretic/glyph-brush/blob/75534d782002db4faf735405ecb4116fe96fdbe1/gfx-glyph/src/builder.rs#L120) for it's up to date documentation