### PR TITLE
Update `wgpu` to `0.8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,20 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.7"
 glyph_brush = "0.7"
 log = "0.4"
 
 [dependencies.bytemuck]
 version = "1.4"
 features = ["derive"]
+
+[dependencies.wgpu]
+version = "0.8"
+# NB: wgpu switched the default shader translator to `naga` in in 0.8.0,
+# but it currently produces syntax errors when translating this crate's shaders
+# to GLSL for `gfx_backend_gl`.
+# So, for now, tell it to use the legacy `spirv_cross` shader translator.
+features = ["cross"] 
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -105,8 +105,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                         &wgpu::RenderPassDescriptor {
                             label: Some("Render pass"),
                             color_attachments: &[
-                                wgpu::RenderPassColorAttachmentDescriptor {
-                                    attachment: &frame.view,
+                                wgpu::RenderPassColorAttachment {
+                                    view: &frame.view,
                                     resolve_target: None,
                                     ops: wgpu::Operations {
                                         load: wgpu::LoadOp::Clear(

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -57,7 +57,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             depth_compare: wgpu::CompareFunction::Greater,
             stencil: wgpu::StencilState::default(),
             bias: wgpu::DepthBiasState::default(),
-            clamp_depth: false,
         })
         .build(&device, FORMAT);
 
@@ -105,8 +104,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                         &wgpu::RenderPassDescriptor {
                             label: Some("Render pass"),
                             color_attachments: &[
-                                wgpu::RenderPassColorAttachmentDescriptor {
-                                    attachment: &frame.view,
+                                wgpu::RenderPassColorAttachment {
+                                    view: &frame.view,
                                     resolve_target: None,
                                     ops: wgpu::Operations {
                                         load: wgpu::LoadOp::Clear(
@@ -162,8 +161,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                         &mut staging_belt,
                         &mut encoder,
                         &frame.view,
-                        wgpu::RenderPassDepthStencilAttachmentDescriptor {
-                            attachment: &depth_view,
+                        wgpu::RenderPassDepthStencilAttachment {
+                            view: &depth_view,
                             depth_ops: Some(wgpu::Operations {
                                 load: wgpu::LoadOp::Clear(-1.0),
                                 store: true,
@@ -221,7 +220,7 @@ fn create_frame_views(
         size: wgpu::Extent3d {
             width,
             height,
-            depth: 1,
+            depth_or_array_layers: 1,
         },
         mip_level_count: 1,
         sample_count: 1,

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -105,8 +105,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                         &wgpu::RenderPassDescriptor {
                             label: Some("Render pass"),
                             color_attachments: &[
-                                wgpu::RenderPassColorAttachmentDescriptor {
-                                    attachment: &frame.view,
+                                wgpu::RenderPassColorAttachment {
+                                    view: &frame.view,
                                     resolve_target: None,
                                     ops: wgpu::Operations {
                                         load: wgpu::LoadOp::Clear(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
         staging_belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
-        depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachmentDescriptor,
+        depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
         target_width: u32,
         target_height: u32,
     ) -> Result<(), String> {
@@ -398,7 +398,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
         staging_belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
-        depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachmentDescriptor,
+        depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
         transform: [f32; 16],
     ) -> Result<(), String> {
         self.process_queued(device, staging_belt, encoder);
@@ -433,7 +433,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
         staging_belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
-        depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachmentDescriptor,
+        depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
         transform: [f32; 16],
         region: Region,
     ) -> Result<(), String> {

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -1,4 +1,4 @@
-use core::num::NonZeroU64;
+use core::num::{NonZeroU32, NonZeroU64};
 
 pub struct Cache {
     texture: wgpu::Texture,
@@ -17,7 +17,7 @@ impl Cache {
             size: wgpu::Extent3d {
                 width,
                 height,
-                depth: 1,
+                depth_or_array_layers: 1,
             },
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Unorm,
@@ -70,7 +70,8 @@ impl Cache {
                 device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some("wgpu_glyph::Cache upload buffer"),
                     size: padded_data_size,
-                    usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::COPY_SRC,
+                    usage: wgpu::BufferUsage::COPY_DST
+                        | wgpu::BufferUsage::COPY_SRC,
                     mapped_at_creation: false,
                 });
 
@@ -91,15 +92,15 @@ impl Cache {
         }
 
         encoder.copy_buffer_to_texture(
-            wgpu::BufferCopyView {
+            wgpu::ImageCopyBuffer {
                 buffer: &self.upload_buffer,
-                layout: wgpu::TextureDataLayout {
+                layout: wgpu::ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: padded_width as u32,
-                    rows_per_image: height as u32,
+                    bytes_per_row: NonZeroU32::new(padded_width as u32),
+                    rows_per_image: NonZeroU32::new(height as u32),
                 },
             },
-            wgpu::TextureCopyView {
+            wgpu::ImageCopyTexture {
                 texture: &self.texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
@@ -111,7 +112,7 @@ impl Cache {
             wgpu::Extent3d {
                 width: size[0] as u32,
                 height: size[1] as u32,
-                depth: 1,
+                depth_or_array_layers: 1,
             },
         );
     }


### PR DESCRIPTION
I drafted this up before I noticed #62 , but I'm submitting this separately anyway for a couple of reasons:

- To make the upgrade to 0.8 separate from the introduction of WGSL.
- To draw attention to a regression caused by `wgpu` switching to `naga` as the default shader translator as of wgpu-0.8.0.