### PR TITLE
Use Queue instead of StagingBelt for buffer/texture writes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.9"
+wgpu = "0.8.1"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.8"
+wgpu = "0.9"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.8.1"
+wgpu = "0.9"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let surface = unsafe { instance.create_surface(&window) };
 
     // Initialize GPU
-    let (device, queue) = futures::executor::block_on(async {
+    let (device, mut queue) = futures::executor::block_on(async {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -32,11 +32,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             .await
             .expect("Request device")
     });
-
-    // Create staging belt and a local pool
-    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
-    let mut local_pool = futures::executor::LocalPool::new();
-    let local_spawner = local_pool.spawner();
 
     // Prepare swap chain and depth buffer
     let mut size = window.inner_size();
@@ -158,7 +153,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
-                        &mut staging_belt,
+                        &mut queue,
                         &mut encoder,
                         &frame.view,
                         wgpu::RenderPassDepthStencilAttachment {
@@ -178,17 +173,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .expect("Draw queued");
 
                 // Submit the work!
-                staging_belt.finish();
                 queue.submit(Some(encoder.finish()));
 
-                // Recall unused staging buffers
-                use futures::task::SpawnExt;
-
-                local_spawner
-                    .spawn(staging_belt.recall())
-                    .expect("Recall staging belt");
-
-                local_pool.run_until_stalled();
             }
             _ => {
                 *control_flow = winit::event_loop::ControlFlow::Wait;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let surface = unsafe { instance.create_surface(&window) };
 
     // Initialize GPU
-    let (device, queue) = futures::executor::block_on(async {
+    let (device, mut queue) = futures::executor::block_on(async {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -30,11 +30,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             .await
             .expect("Request device")
     });
-
-    // Create staging belt and a local pool
-    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
-    let mut local_pool = futures::executor::LocalPool::new();
-    let local_spawner = local_pool.spawner();
 
     // Prepare swap chain
     let render_format = wgpu::TextureFormat::Bgra8UnormSrgb;
@@ -148,7 +143,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
-                        &mut staging_belt,
+                        &mut queue,
                         &mut encoder,
                         &frame.view,
                         size.width,
@@ -157,17 +152,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .expect("Draw queued");
 
                 // Submit the work!
-                staging_belt.finish();
                 queue.submit(Some(encoder.finish()));
-
-                // Recall unused staging buffers
-                use futures::task::SpawnExt;
-
-                local_spawner
-                    .spawn(staging_belt.recall())
-                    .expect("Recall staging belt");
-
-                local_pool.run_until_stalled();
+                
             }
             _ => {
                 *control_flow = winit::event_loop::ControlFlow::Wait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ where
     fn process_queued(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
     ) {
         let pipeline = &mut self.pipeline;
@@ -153,7 +153,7 @@ where
 
                     pipeline.update_cache(
                         device,
-                        staging_belt,
+                        queue,
                         encoder,
                         offset,
                         size,
@@ -201,7 +201,7 @@ where
 
         match brush_action.unwrap() {
             BrushAction::Draw(verts) => {
-                self.pipeline.upload(device, staging_belt, encoder, &verts);
+                self.pipeline.upload(device, queue, encoder, &verts);
             }
             BrushAction::ReDraw => {}
         };
@@ -243,7 +243,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     pub fn draw_queued(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         target_width: u32,
@@ -251,7 +251,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     ) -> Result<(), String> {
         self.draw_queued_with_transform(
             device,
-            staging_belt,
+            queue,
             encoder,
             target,
             orthographic_projection(target_width, target_height),
@@ -273,15 +273,15 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     pub fn draw_queued_with_transform(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         transform: [f32; 16],
     ) -> Result<(), String> {
-        self.process_queued(device, staging_belt, encoder);
+        self.process_queued(device, queue, encoder);
         self.pipeline.draw(
             device,
-            staging_belt,
+            queue,
             encoder,
             target,
             transform,
@@ -306,16 +306,16 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     pub fn draw_queued_with_transform_and_scissoring(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         transform: [f32; 16],
         region: Region,
     ) -> Result<(), String> {
-        self.process_queued(device, staging_belt, encoder);
+        self.process_queued(device, queue, encoder);
         self.pipeline.draw(
             device,
-            staging_belt,
+            queue,
             encoder,
             target,
             transform,
@@ -363,7 +363,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     pub fn draw_queued(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
@@ -372,7 +372,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     ) -> Result<(), String> {
         self.draw_queued_with_transform(
             device,
-            staging_belt,
+            queue,
             encoder,
             target,
             depth_stencil_attachment,
@@ -395,16 +395,16 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     pub fn draw_queued_with_transform(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
         transform: [f32; 16],
     ) -> Result<(), String> {
-        self.process_queued(device, staging_belt, encoder);
+        self.process_queued(device, queue, encoder);
         self.pipeline.draw(
             device,
-            staging_belt,
+            queue,
             encoder,
             target,
             depth_stencil_attachment,
@@ -430,18 +430,18 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     pub fn draw_queued_with_transform_and_scissoring(
         &mut self,
         device: &wgpu::Device,
-        staging_belt: &mut wgpu::util::StagingBelt,
+        queue: &mut wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
         transform: [f32; 16],
         region: Region,
     ) -> Result<(), String> {
-        self.process_queued(device, staging_belt, encoder);
+        self.process_queued(device, queue, encoder);
 
         self.pipeline.draw(
             device,
-            staging_belt,
+            queue,
             encoder,
             target,
             depth_stencil_attachment,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -2,13 +2,10 @@ use std::num::NonZeroU32;
 
 pub struct Cache {
     texture: wgpu::Texture,
-    pub(super) view: wgpu::TextureView,
-    padded_cache: Vec<u8>
+    pub(super) view: wgpu::TextureView
 }
 
 impl Cache {
-    const INITIAL_UPLOAD_BUFFER_SIZE: u64 =
-        wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as u64 * 100;
 
     pub fn new(device: &wgpu::Device, width: u32, height: u32) -> Cache {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -27,13 +24,9 @@ impl Cache {
 
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let mut padded_cache = Vec::new();
-        padded_cache.reserve(Self::INITIAL_UPLOAD_BUFFER_SIZE as usize);
-
         Cache {
             texture,
-            view,
-            padded_cache
+            view
         }
     }
 
@@ -49,24 +42,6 @@ impl Cache {
         let width = size[0] as usize;
         let height = size[1] as usize;
 
-        // It is a webgpu requirement that:
-        //  BufferCopyView.layout.bytes_per_row % wgpu::COPY_BYTES_PER_ROW_ALIGNMENT == 0
-        // So we calculate padded_width by rounding width
-        // up to the next multiple of wgpu::COPY_BYTES_PER_ROW_ALIGNMENT.
-        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
-        let padded_width_padding = (align - width % align) % align;
-        let padded_width = width + padded_width_padding;
-
-        let padded_data_size = (padded_width * height) as u64;
-        self.padded_cache.resize(padded_data_size as usize, 0);
-
-        let padded_data = self.padded_cache.as_mut_slice();
-
-        for row in 0..height {
-            padded_data[row * padded_width..row * padded_width + width]
-                .copy_from_slice(&data[row * width..(row + 1) * width]);
-        }
-
         queue.write_texture(
             wgpu::ImageCopyTexture {
                 texture: &self.texture,
@@ -77,10 +52,10 @@ impl Cache {
                     z: 0,
                 },
             },
-            &padded_data,
+            &data,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: NonZeroU32::new(padded_width as u32),
+                bytes_per_row: NonZeroU32::new(width as u32),
                 rows_per_image: NonZeroU32::new(height as u32),
             },
             wgpu::Extent3d {


### PR DESCRIPTION
I was having a situation where StagingBelt was leaking a tremendous amount of memory (like 10MB/second given my use of wgpu_glyph, so I took the liberty of swapping out StagingBelt use for Queue), it seems you may already have had the same idea given the comment inside cache.rs?

I also fixed my issue with the cache being corrupted (it was me leaving in half the buffer use that wasn't necessary anymore, order of writes to queue vs encoder use wasn't what I expected), the only thing which might be a little weird is the now local Vec kept in cache.rs to hold the padded data and the use of unsafe there for set_len, but here it is anyways, ready for review 👀 