### PR TITLE
Update `wgpu` to `0.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.8"
+wgpu = "0.9"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -296,32 +296,12 @@ fn build<D>(
             buffers: &[wgpu::VertexBufferLayout {
                 array_stride: mem::size_of::<Instance>() as u64,
                 step_mode: wgpu::InputStepMode::Instance,
-                attributes: &[
-                    wgpu::VertexAttribute {
-                        shader_location: 0,
-                        format: wgpu::VertexFormat::Float32x3,
-                        offset: 0,
-                    },
-                    wgpu::VertexAttribute {
-                        shader_location: 1,
-                        format: wgpu::VertexFormat::Float32x2,
-                        offset: 4 * 3,
-                    },
-                    wgpu::VertexAttribute {
-                        shader_location: 2,
-                        format: wgpu::VertexFormat::Float32x2,
-                        offset: 4 * (3 + 2),
-                    },
-                    wgpu::VertexAttribute {
-                        shader_location: 3,
-                        format: wgpu::VertexFormat::Float32x2,
-                        offset: 4 * (3 + 2 + 2),
-                    },
-                    wgpu::VertexAttribute {
-                        shader_location: 4,
-                        format: wgpu::VertexFormat::Float32x4,
-                        offset: 4 * (3 + 2 + 2 + 2),
-                    },
+                attributes: &wgpu::vertex_attr_array![
+                    0 => Float32x3,
+                    1 => Float32x2,
+                    2 => Float32x2,
+                    3 => Float32x2,
+                    4 => Float32x4,
                 ],
             }],
         },


### PR DESCRIPTION
- Update wgpu to 0.9 (no changes required)
- While at it, I replaced manually defined vertex attributes with wgpu built-in macro (if there was any reason for those to be manually defined then I can just drop the commit, just let me know)