### PR TITLE
Add default branch to wgsl switch

### DIFF
--- a/src/shader/glyph.wgsl
+++ b/src/shader/glyph.wgsl
@@ -49,8 +49,9 @@ fn vs_main(input: VertexInput) -> VertexOutput {
             pos = vec2<f32>(right, bottom);
             out.f_tex_pos = input.tex_right_bottom;
         }
+        default: {}
     }
-    
+
     out.f_color = input.color;
     out.position = globals.transform * vec4<f32>(pos, input.left_top.z, 1.0);
 


### PR DESCRIPTION
From the WGSL spec: "Each switch statement must have exactly one default clause."

Chrome/Tint emits the following error when compiling the shader:
```
Tint WGSL reader failure:
Parser: 35:5 error: switch statement must have a default clause
    switch (i32(input.vertex_index)) {
    ^^^^^^
```

naga doesn't yet validate the presence of a default clause but should do so soonish via https://github.com/gfx-rs/naga/pull/1529.