### PR TITLE
Make wgpu_glyph work on Chrome

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -308,6 +308,7 @@ fn build<D>(
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleStrip,
             front_face: wgpu::FrontFace::Cw,
+            strip_index_format: Some(wgpu::IndexFormat::Uint16),
             ..Default::default()
         },
         depth_stencil,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -247,7 +247,7 @@ fn build<D>(
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float {
-                            filterable: false,
+                            filterable: true,
                         },
                         view_dimension: wgpu::TextureViewDimension::D2,
                         multisampled: false,


### PR DESCRIPTION
Followup to https://github.com/hecrj/wgpu_glyph/pull/79. See the commit messages for details. With these fixes wgpu_glyph works in Chrome Canary. :tada: