### PR TITLE
Fix shader compile error for recent Tint update (wasm32, chrome)

### DIFF
--- a/src/shader/glyph.wgsl
+++ b/src/shader/glyph.wgsl
@@ -1,3 +1,4 @@
+[[block]]
 struct Globals {
     transform: mat4x4<f32>;
 };


### PR DESCRIPTION
After recent update tint refuses to compile current shader with "block decoration" error, https://dawn.googlesource.com/tint/