### PR TITLE
Add support for passing a multisample state

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,6 +10,7 @@ use super::GlyphBrush;
 pub struct GlyphBrushBuilder<D, F, H = DefaultSectionHasher> {
     inner: glyph_brush::GlyphBrushBuilder<F, H>,
     texture_filter_method: wgpu::FilterMode,
+    multisample_state: wgpu::MultisampleState,
     depth: D,
 }
 
@@ -20,6 +21,7 @@ impl<F, H> From<glyph_brush::GlyphBrushBuilder<F, H>>
         GlyphBrushBuilder {
             inner,
             texture_filter_method: wgpu::FilterMode::Linear,
+            multisample_state: wgpu::MultisampleState::default(),
             depth: (),
         }
     }
@@ -37,6 +39,7 @@ impl GlyphBrushBuilder<(), ()> {
         GlyphBrushBuilder {
             inner: glyph_brush::GlyphBrushBuilder::using_fonts(fonts),
             texture_filter_method: wgpu::FilterMode::Linear,
+            multisample_state: wgpu::MultisampleState::default(),
             depth: (),
         }
     }
@@ -71,6 +74,15 @@ impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
         self
     }
 
+    /// Sets the multi-sampling state of the render pipeline.
+    pub fn multisample_state(
+        mut self,
+        multisample_state: wgpu::MultisampleState,
+    ) -> Self {
+        self.multisample_state = multisample_state;
+        self
+    }
+
     /// Sets the section hasher. `GlyphBrush` cannot handle absolute section
     /// hash collisions so use a good hash algorithm.
     ///
@@ -85,6 +97,7 @@ impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
         GlyphBrushBuilder {
             inner: self.inner.section_hasher(section_hasher),
             texture_filter_method: self.texture_filter_method,
+            multisample_state: self.multisample_state,
             depth: self.depth,
         }
     }
@@ -97,6 +110,7 @@ impl<F: Font, D, H: BuildHasher> GlyphBrushBuilder<D, F, H> {
         GlyphBrushBuilder {
             inner: self.inner,
             texture_filter_method: self.texture_filter_method,
+            multisample_state: self.multisample_state,
             depth: depth_stencil_state,
         }
     }
@@ -113,6 +127,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrushBuilder<(), F, H> {
         GlyphBrush::<(), F, H>::new(
             device,
             self.texture_filter_method,
+            self.multisample_state,
             render_format,
             self.inner,
         )
@@ -132,6 +147,7 @@ impl<F: Font + Sync, H: BuildHasher>
         GlyphBrush::<wgpu::DepthStencilState, F, H>::new(
             device,
             self.texture_filter_method,
+            self.multisample_state,
             render_format,
             self.depth,
             self.inner,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     fn new(
         device: &wgpu::Device,
         filter_mode: wgpu::FilterMode,
+        multisample: wgpu::MultisampleState,
         render_format: wgpu::TextureFormat,
         raw_builder: glyph_brush::GlyphBrushBuilder<F, H>,
     ) -> Self {
@@ -222,6 +223,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
             pipeline: Pipeline::<()>::new(
                 device,
                 filter_mode,
+                multisample,
                 render_format,
                 cache_width,
                 cache_height,
@@ -331,6 +333,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     fn new(
         device: &wgpu::Device,
         filter_mode: wgpu::FilterMode,
+        multisample: wgpu::MultisampleState,
         render_format: wgpu::TextureFormat,
         depth_stencil_state: wgpu::DepthStencilState,
         raw_builder: glyph_brush::GlyphBrushBuilder<F, H>,
@@ -341,6 +344,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
             pipeline: Pipeline::<wgpu::DepthStencilState>::new(
                 device,
                 filter_mode,
+                multisample,
                 render_format,
                 depth_stencil_state,
                 cache_width,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -27,6 +27,7 @@ impl Pipeline<()> {
     pub fn new(
         device: &wgpu::Device,
         filter_mode: wgpu::FilterMode,
+        multisample: wgpu::MultisampleState,
         render_format: wgpu::TextureFormat,
         cache_width: u32,
         cache_height: u32,
@@ -34,6 +35,7 @@ impl Pipeline<()> {
         build(
             device,
             filter_mode,
+            multisample,
             render_format,
             None,
             cache_width,
@@ -67,6 +69,7 @@ impl Pipeline<wgpu::DepthStencilState> {
     pub fn new(
         device: &wgpu::Device,
         filter_mode: wgpu::FilterMode,
+        multisample: wgpu::MultisampleState,
         render_format: wgpu::TextureFormat,
         depth_stencil_state: wgpu::DepthStencilState,
         cache_width: u32,
@@ -75,6 +78,7 @@ impl Pipeline<wgpu::DepthStencilState> {
         build(
             device,
             filter_mode,
+            multisample,
             render_format,
             Some(depth_stencil_state),
             cache_width,
@@ -191,6 +195,7 @@ const IDENTITY_MATRIX: [f32; 16] = [
 fn build<D>(
     device: &wgpu::Device,
     filter_mode: wgpu::FilterMode,
+    multisample: wgpu::MultisampleState,
     render_format: wgpu::TextureFormat,
     depth_stencil: Option<wgpu::DepthStencilState>,
     cache_width: u32,
@@ -311,7 +316,7 @@ fn build<D>(
             ..Default::default()
         },
         depth_stencil,
-        multisample: wgpu::MultisampleState::default(),
+        multisample,
         fragment: Some(wgpu::FragmentState {
             module: &shader,
             entry_point: "fs_main",


### PR DESCRIPTION
This adds a function to the builder to allow setting the multisample
state. If it is not called, the default is used as before.