### PR TITLE
Updated to wgpu 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 resolver = "2"
 
 [dependencies]
-wgpu = "0.14"
+wgpu = "0.15"
 glyph_brush = "0.7"
 log = "0.4"
 
@@ -21,6 +21,6 @@ version = "1.9"
 features = ["derive"]
 
 [dev-dependencies]
-env_logger = "0.9"
-winit = "0.27"
+env_logger = "0.10.0"
+winit = "0.28.2"
 futures = "0.3"

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use wgpu::CompositeAlphaMode;
+use wgpu::{CompositeAlphaMode};
 use wgpu_glyph::{ab_glyph, GlyphBrushBuilder, Region, Section, Text};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -13,8 +13,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build(&event_loop)
         .unwrap();
 
-    let instance = wgpu::Instance::new(wgpu::Backends::all());
-    let surface = unsafe { instance.create_surface(&window) };
+    let instance = wgpu::Instance::new(
+        wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            dx12_shader_compiler: Default::default(),
+        });
+    let surface = unsafe { instance.create_surface(&window) }.unwrap();
 
     // Initialize GPU
     let (device, queue) = futures::executor::block_on(async {
@@ -45,10 +49,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         &wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: render_format,
+            view_formats: vec![],
             width: size.width,
             height: size.height,
             present_mode: wgpu::PresentMode::AutoVsync,
-            alpha_mode: CompositeAlphaMode::Auto
+            alpha_mode: CompositeAlphaMode::Auto,
         },
     );
 
@@ -80,10 +85,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                     &wgpu::SurfaceConfiguration {
                         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                         format: render_format,
+                        view_formats: vec![],
                         width: size.width,
                         height: size.height,
                         present_mode: wgpu::PresentMode::AutoVsync,
-                        alpha_mode: CompositeAlphaMode::Auto
+                        alpha_mode: CompositeAlphaMode::Auto,
                     },
                 );
             }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -15,8 +15,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build(&event_loop)
         .unwrap();
 
-    let instance = wgpu::Instance::new(wgpu::Backends::all());
-    let surface = unsafe { instance.create_surface(&window) };
+    let instance = wgpu::Instance::new(
+        wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            dx12_shader_compiler: Default::default(),
+        });
+    let surface = unsafe { instance.create_surface(&window) }.unwrap();
 
     // Initialize GPU
     let (device, queue) = futures::executor::block_on(async {
@@ -200,6 +204,7 @@ fn create_frame_views(
         &wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: FORMAT,
+            view_formats: vec![],
             width,
             height,
             present_mode: wgpu::PresentMode::AutoVsync,
@@ -218,6 +223,7 @@ fn create_frame_views(
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
         format: wgpu::TextureFormat::Depth32Float,
+        view_formats: &[],
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
     });
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -13,8 +13,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build(&event_loop)
         .unwrap();
 
-    let instance = wgpu::Instance::new(wgpu::Backends::all());
-    let surface = unsafe { instance.create_surface(&window) };
+    let instance = wgpu::Instance::new(
+        wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            dx12_shader_compiler: Default::default(),
+        });
+    let surface = unsafe { instance.create_surface(&window) }.unwrap();
 
     // Initialize GPU
     let (device, queue) = futures::executor::block_on(async {
@@ -45,6 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         &wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: render_format,
+            view_formats: vec![],
             width: size.width,
             height: size.height,
             present_mode: wgpu::PresentMode::AutoVsync,
@@ -80,6 +85,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     &wgpu::SurfaceConfiguration {
                         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                         format: render_format,
+                        view_formats: vec![],
                         width: size.width,
                         height: size.height,
                         present_mode: wgpu::PresentMode::AutoVsync,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -22,6 +22,7 @@ impl Cache {
             },
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Unorm,
+            view_formats: &[wgpu::TextureFormat::R8Unorm],
             usage: wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::TEXTURE_BINDING,
             mip_level_count: 1,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -22,7 +22,7 @@ impl Cache {
             },
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Unorm,
-            view_formats: &[wgpu::TextureFormat::R8Unorm],
+            view_formats: &[],
             usage: wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::TEXTURE_BINDING,
             mip_level_count: 1,


### PR DESCRIPTION
This upgrade `wgpu_glyph` to `wgpu` 0.15.

- Some changes to surface creation 
- Texture views can have their own format 

I have tested the branch with my UI library, and it works.
<img width="150" alt="image" src="https://user-images.githubusercontent.com/23613882/223836801-3f714baf-2497-4c41-a5b4-301add95edf6.png">
