### PR TITLE
Update wgpu to 0.19 and winit to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ features = ["derive"]
 
 [dev-dependencies]
 env_logger = "0.10"
-winit = "0.28"
+winit = { version = "0.29", features = ["rwh_05"] }
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.18"
+wgpu = "0.19"
 glyph_brush = "0.7"
 log = "0.4"
 
@@ -21,5 +21,5 @@ features = ["derive"]
 
 [dev-dependencies]
 env_logger = "0.10"
-winit = { version = "0.29", features = ["rwh_05"] }
+winit = "0.29"
 futures = "0.3"

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     // Open window and create a surface
-    let event_loop = winit::event_loop::EventLoop::new();
+    let event_loop = winit::event_loop::EventLoop::new()?;
 
     let window = winit::window::WindowBuilder::new()
         .with_resizable(false)
@@ -64,12 +64,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Render loop
     window.request_redraw();
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         match event {
             winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = winit::event_loop::ControlFlow::Exit,
+            } => elwt.exit(),
             winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::Resized(new_size),
                 ..
@@ -89,7 +89,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     },
                 );
             }
-            winit::event::Event::MainEventsCleared => {
+            winit::event::Event::WindowEvent {
+                event: winit::event::WindowEvent::RedrawRequested,
+                ..
+            } => {
                 // Get a command encoder for the current frame
                 let mut encoder = device.create_command_encoder(
                     &wgpu::CommandEncoderDescriptor {
@@ -190,9 +193,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 // Recall unused staging buffers
                 staging_belt.recall();
             }
-            _ => {
-                *control_flow = winit::event_loop::ControlFlow::Wait;
-            }
+            _ => {}
         }
-    })
+    }).map_err(Into::into)
 }

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
-    let surface = unsafe { instance.create_surface(&window)? };
+    let surface = instance.create_surface(&window)?;
 
     // Initialize GPU
     let (device, queue) = futures::executor::block_on(async {
@@ -50,6 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: CompositeAlphaMode::Auto,
             view_formats: vec![],
+            desired_maximum_frame_latency: 2,
         },
     );
 
@@ -86,6 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         present_mode: wgpu::PresentMode::AutoVsync,
                         alpha_mode: CompositeAlphaMode::Auto,
                         view_formats: vec![],
+                        desired_maximum_frame_latency: 2,
                     },
                 );
             }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
-    let surface = unsafe { instance.create_surface(&window)? };
+    let surface = instance.create_surface(&window)?;
 
     // Initialize GPU
     let (device, queue) = futures::executor::block_on(async {
@@ -208,6 +208,7 @@ fn create_frame_views(
             present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: CompositeAlphaMode::Auto,
             view_formats: vec![],
+            desired_maximum_frame_latency: 2,
         },
     );
 

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     // Open window and create a surface
-    let event_loop = winit::event_loop::EventLoop::new();
+    let event_loop = winit::event_loop::EventLoop::new()?;
 
     let window = winit::window::WindowBuilder::new()
         .with_resizable(false)
@@ -62,19 +62,22 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Render loop
     window.request_redraw();
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         match event {
             winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = winit::event_loop::ControlFlow::Exit,
+            } => elwt.exit(),
             winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::Resized(size),
                 ..
             } => {
                 new_size = Some(size);
             }
-            winit::event::Event::RedrawRequested { .. } => {
+            winit::event::Event::WindowEvent {
+                event: winit::event::WindowEvent::RedrawRequested,
+                ..
+            } => {
                 if let Some(new_size) = new_size.take() {
                     depth_view =
                         create_frame_views(&device, &surface, new_size);
@@ -183,11 +186,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                 // Recall unused staging buffers
                 staging_belt.recall();
             }
-            _ => {
-                *control_flow = winit::event_loop::ControlFlow::Wait;
-            }
+            _ => {}
         }
-    })
+    }).map_err(Into::into)
 }
 
 fn create_frame_views(

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     // Open window and create a surface
-    let event_loop = winit::event_loop::EventLoop::new();
+    let event_loop = winit::event_loop::EventLoop::new()?;
 
     let window = winit::window::WindowBuilder::new()
         .with_resizable(false)
@@ -64,12 +64,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Render loop
     window.request_redraw();
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         match event {
             winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = winit::event_loop::ControlFlow::Exit,
+            } => elwt.exit(),
             winit::event::Event::WindowEvent {
                 event: winit::event::WindowEvent::Resized(new_size),
                 ..
@@ -89,7 +89,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     },
                 );
             }
-            winit::event::Event::RedrawRequested { .. } => {
+            winit::event::Event::WindowEvent {
+                event: winit::event::WindowEvent::RedrawRequested,
+                ..
+            } => {
                 // Get a command encoder for the current frame
                 let mut encoder = device.create_command_encoder(
                     &wgpu::CommandEncoderDescriptor {
@@ -170,9 +173,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 // Recall unused staging buffers
                 staging_belt.recall();
             }
-            _ => {
-                *control_flow = winit::event_loop::ControlFlow::Wait;
-            }
+            _ => {}
         }
-    })
+    }).map_err(Into::into)
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
-    let surface = unsafe { instance.create_surface(&window)? };
+    let surface = instance.create_surface(&window)?;
 
     // Initialize GPU
     let (device, queue) = futures::executor::block_on(async {
@@ -50,6 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: CompositeAlphaMode::Auto,
             view_formats: vec![],
+            desired_maximum_frame_latency: 2,
         },
     );
 
@@ -86,6 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         present_mode: wgpu::PresentMode::AutoVsync,
                         alpha_mode: CompositeAlphaMode::Auto,
                         view_formats: vec![render_format],
+                        desired_maximum_frame_latency: 2,
                     },
                 );
             }

--- a/src/shader/glyph.wgsl
+++ b/src/shader/glyph.wgsl
@@ -8,62 +8,62 @@ struct Globals {
 
 struct VertexInput {
     @builtin(vertex_index) vertex_index: u32,
-    @location(0) left_top: vec3<f32>,
-    @location(1) right_bottom: vec2<f32>,
-    @location(2) tex_left_top: vec2<f32>,
-    @location(3) tex_right_bottom: vec2<f32>,
-    @location(4) color: vec4<f32>,
+    @location(0) left_top: vec3f,
+    @location(1) right_bottom: vec2f,
+    @location(2) tex_left_top: vec2f,
+    @location(3) tex_right_bottom: vec2f,
+    @location(4) color: vec4f,
 }
 
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) f_tex_pos: vec2<f32>,
-    @location(1) f_color: vec4<f32>,
+    @builtin(position) position: vec4f,
+    @location(0) f_tex_pos: vec2f,
+    @location(1) f_color: vec4f,
 }
 
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
 
-    var pos: vec2<f32> = vec2<f32>(0.0, 0.0);
-    var left: f32 = input.left_top.x;
-    var right: f32 = input.right_bottom.x;
-    var top: f32 = input.left_top.y;
-    var bottom: f32 = input.right_bottom.y;
+    var pos = vec2f(0, 0);
+    let left = input.left_top.x;
+    let right = input.right_bottom.x;
+    let top = input.left_top.y;
+    let bottom = input.right_bottom.y;
 
-    switch (i32(input.vertex_index)) {
-        case 0: {
-            pos = vec2<f32>(left, top);
+    switch input.vertex_index {
+        case 0u: {
+            pos = vec2(left, top);
             out.f_tex_pos = input.tex_left_top;
         }
-        case 1: {
-            pos = vec2<f32>(right, top);
-            out.f_tex_pos = vec2<f32>(input.tex_right_bottom.x, input.tex_left_top.y);
+        case 1u: {
+            pos = vec2(right, top);
+            out.f_tex_pos = vec2(input.tex_right_bottom.x, input.tex_left_top.y);
         }
-        case 2: {
-            pos = vec2<f32>(left, bottom);
-            out.f_tex_pos = vec2<f32>(input.tex_left_top.x, input.tex_right_bottom.y);
+        case 2u: {
+            pos = vec2(left, bottom);
+            out.f_tex_pos = vec2(input.tex_left_top.x, input.tex_right_bottom.y);
         }
-        case 3: {
-            pos = vec2<f32>(right, bottom);
+        case 3u: {
+            pos = vec2(right, bottom);
             out.f_tex_pos = input.tex_right_bottom;
         }
         default: {}
     }
 
     out.f_color = input.color;
-    out.position = globals.transform * vec4<f32>(pos, input.left_top.z, 1.0);
+    out.position = globals.transform * vec4(pos, input.left_top.z, 1.0);
 
     return out;
 }
 
 @fragment
-fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    var alpha: f32 = textureSample(font_tex, font_sampler, input.f_tex_pos).r;
+fn fs_main(input: VertexOutput) -> @location(0) vec4f {
+    var alpha = textureSample(font_tex, font_sampler, input.f_tex_pos).r;
 
     if (alpha <= 0.0) {
         discard;
     }
 
-    return input.f_color * vec4<f32>(1.0, 1.0, 1.0, alpha);
+    return input.f_color * vec4f(1.0, 1.0, 1.0, alpha);
 }


### PR DESCRIPTION
The wgpu update is useful for users of this crate, while the winit update is only relevant to the examples in this repo. I also touched up the WGSL code. If you prefer, I can remove the last commit.

This can be be reviewed commit by commit.

Changelogs: [wgpu](https://github.com/gfx-rs/wgpu/releases/tag/v0.19.0), [winit](https://github.com/rust-windowing/winit/releases/tag/v0.29.2)

---

Thanks for this crate btw. I know the README now says this has been superseeded by [glyphon](https://github.com/grovesNL/glyphon), but I still think there is a place for `wgpu_glyph`. At least for now. Switching to glyphon isn't straight forward if you are already using `wgpu_glyph` and cosmic-text still lacks some features like changing font size within one text block. So thanks for still maintaining this!