### PR TITLE
Upgrade wgpu to 23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "0.19"
+wgpu = "23"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -293,10 +293,11 @@ fn build<D>(
 
     let raw = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
         label: None,
+        cache: None,
         layout: Some(&layout),
         vertex: wgpu::VertexState {
             module: &shader,
-            entry_point: "vs_main",
+            entry_point: Some("vs_main"),
             buffers: &[wgpu::VertexBufferLayout {
                 array_stride: mem::size_of::<Instance>() as u64,
                 step_mode: wgpu::VertexStepMode::Instance,
@@ -308,6 +309,7 @@ fn build<D>(
                     4 => Float32x4,
                 ],
             }],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
         },
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleStrip,
@@ -319,7 +321,7 @@ fn build<D>(
         multisample,
         fragment: Some(wgpu::FragmentState {
             module: &shader,
-            entry_point: "fs_main",
+            entry_point: Some("fs_main"),
             targets: &[Some(wgpu::ColorTargetState {
                 format: render_format,
                 blend: Some(wgpu::BlendState {
@@ -336,6 +338,7 @@ fn build<D>(
                 }),
                 write_mask: wgpu::ColorWrites::ALL,
             })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
         }),
         multiview: None,
     });


### PR DESCRIPTION
This upgrades the wgpu version from 0.19 to 23.
Only some minor changes were necessary.

Even though this crate is discontinued, it would be nice to be able to keep using it with recent versions of wgpu for projects that depend on it currently and don't want to move everything to glyphon yet.