### PR TITLE
Upgrade wgpu to 26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "23"
+wgpu = "26"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build(&event_loop)
         .unwrap();
 
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
     let surface = instance.create_surface(&window)?;
 
     // Initialize GPU
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .expect("Request adapter");
 
         adapter
-            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .request_device(&wgpu::DeviceDescriptor::default())
             .await
             .expect("Request device")
     });
@@ -65,137 +65,140 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Render loop
     window.request_redraw();
 
-    event_loop.run(move |event, elwt| {
-        match event {
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::CloseRequested,
-                ..
-            } => elwt.exit(),
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::Resized(new_size),
-                ..
-            } => {
-                size = new_size;
+    event_loop
+        .run(move |event, elwt| {
+            match event {
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::CloseRequested,
+                    ..
+                } => elwt.exit(),
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::Resized(new_size),
+                    ..
+                } => {
+                    size = new_size;
 
-                surface.configure(
-                    &device,
-                    &wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: render_format,
-                        width: size.width,
-                        height: size.height,
-                        present_mode: wgpu::PresentMode::AutoVsync,
-                        alpha_mode: CompositeAlphaMode::Auto,
-                        view_formats: vec![],
-                        desired_maximum_frame_latency: 2,
-                    },
-                );
-            }
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::RedrawRequested,
-                ..
-            } => {
-                // Get a command encoder for the current frame
-                let mut encoder = device.create_command_encoder(
-                    &wgpu::CommandEncoderDescriptor {
-                        label: Some("Redraw"),
-                    },
-                );
-
-                // Get the next frame
-                let frame =
-                    surface.get_current_texture().expect("Get next frame");
-                let view = &frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
-
-                // Clear frame
-                {
-                    let _ = encoder.begin_render_pass(
-                        &wgpu::RenderPassDescriptor {
-                            label: Some("Render pass"),
-                            color_attachments: &[Some(
-                                wgpu::RenderPassColorAttachment {
-                                    view,
-                                    resolve_target: None,
-                                    ops: wgpu::Operations {
-                                        load: wgpu::LoadOp::Clear(
-                                            wgpu::Color {
-                                                r: 0.4,
-                                                g: 0.4,
-                                                b: 0.4,
-                                                a: 1.0,
-                                            },
-                                        ),
-                                        store: wgpu::StoreOp::Store,
-                                    },
-                                },
-                            )],
-                            depth_stencil_attachment: None,
-                            timestamp_writes: None,
-                            occlusion_query_set: None,
+                    surface.configure(
+                        &device,
+                        &wgpu::SurfaceConfiguration {
+                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                            format: render_format,
+                            width: size.width,
+                            height: size.height,
+                            present_mode: wgpu::PresentMode::AutoVsync,
+                            alpha_mode: CompositeAlphaMode::Auto,
+                            view_formats: vec![],
+                            desired_maximum_frame_latency: 2,
                         },
                     );
                 }
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::RedrawRequested,
+                    ..
+                } => {
+                    // Get a command encoder for the current frame
+                    let mut encoder = device.create_command_encoder(
+                        &wgpu::CommandEncoderDescriptor {
+                            label: Some("Redraw"),
+                        },
+                    );
 
-                glyph_brush.queue(Section {
-                    screen_position: (30.0, 30.0),
-                    bounds: (size.width as f32, size.height as f32),
-                    text: vec![Text::new("Hello wgpu_glyph!")
-                        .with_color([0.0, 0.0, 0.0, 1.0])
-                        .with_scale(40.0)],
-                    ..Section::default()
-                });
+                    // Get the next frame
+                    let frame =
+                        surface.get_current_texture().expect("Get next frame");
+                    let view = &frame
+                        .texture
+                        .create_view(&wgpu::TextureViewDescriptor::default());
 
-                // Draw the text!
-                glyph_brush
-                    .draw_queued(
-                        &device,
-                        &mut staging_belt,
-                        &mut encoder,
-                        view,
-                        size.width,
-                        size.height,
-                    )
-                    .expect("Draw queued");
+                    // Clear frame
+                    {
+                        let _ = encoder.begin_render_pass(
+                            &wgpu::RenderPassDescriptor {
+                                label: Some("Render pass"),
+                                color_attachments: &[Some(
+                                    wgpu::RenderPassColorAttachment {
+                                        view,
+                                        resolve_target: None,
+                                        ops: wgpu::Operations {
+                                            load: wgpu::LoadOp::Clear(
+                                                wgpu::Color {
+                                                    r: 0.4,
+                                                    g: 0.4,
+                                                    b: 0.4,
+                                                    a: 1.0,
+                                                },
+                                            ),
+                                            store: wgpu::StoreOp::Store,
+                                        },
+                                        depth_slice: None,
+                                    },
+                                )],
+                                depth_stencil_attachment: None,
+                                timestamp_writes: None,
+                                occlusion_query_set: None,
+                            },
+                        );
+                    }
 
-                glyph_brush.queue(Section {
-                    screen_position: (30.0, 90.0),
-                    bounds: (size.width as f32, size.height as f32),
-                    text: vec![Text::new("Hello wgpu_glyph!")
-                        .with_color([1.0, 1.0, 1.0, 1.0])
-                        .with_scale(40.0)],
-                    ..Section::default()
-                });
+                    glyph_brush.queue(Section {
+                        screen_position: (30.0, 30.0),
+                        bounds: (size.width as f32, size.height as f32),
+                        text: vec![Text::new("Hello wgpu_glyph!")
+                            .with_color([0.0, 0.0, 0.0, 1.0])
+                            .with_scale(40.0)],
+                        ..Section::default()
+                    });
 
-                // Draw the text!
-                glyph_brush
-                    .draw_queued_with_transform_and_scissoring(
-                        &device,
-                        &mut staging_belt,
-                        &mut encoder,
-                        view,
-                        wgpu_glyph::orthographic_projection(
+                    // Draw the text!
+                    glyph_brush
+                        .draw_queued(
+                            &device,
+                            &mut staging_belt,
+                            &mut encoder,
+                            view,
                             size.width,
                             size.height,
-                        ),
-                        Region {
-                            x: 40,
-                            y: 105,
-                            width: 200,
-                            height: 15,
-                        },
-                    )
-                    .expect("Draw queued");
+                        )
+                        .expect("Draw queued");
 
-                // Submit the work!
-                staging_belt.finish();
-                queue.submit(Some(encoder.finish()));
-                frame.present();
-                // Recall unused staging buffers
-                staging_belt.recall();
+                    glyph_brush.queue(Section {
+                        screen_position: (30.0, 90.0),
+                        bounds: (size.width as f32, size.height as f32),
+                        text: vec![Text::new("Hello wgpu_glyph!")
+                            .with_color([1.0, 1.0, 1.0, 1.0])
+                            .with_scale(40.0)],
+                        ..Section::default()
+                    });
+
+                    // Draw the text!
+                    glyph_brush
+                        .draw_queued_with_transform_and_scissoring(
+                            &device,
+                            &mut staging_belt,
+                            &mut encoder,
+                            view,
+                            wgpu_glyph::orthographic_projection(
+                                size.width,
+                                size.height,
+                            ),
+                            Region {
+                                x: 40,
+                                y: 105,
+                                width: 200,
+                                height: 15,
+                            },
+                        )
+                        .expect("Draw queued");
+
+                    // Submit the work!
+                    staging_belt.finish();
+                    queue.submit(Some(encoder.finish()));
+                    frame.present();
+                    // Recall unused staging buffers
+                    staging_belt.recall();
+                }
+                _ => {}
             }
-            _ => {}
-        }
-    }).map_err(Into::into)
+        })
+        .map_err(Into::into)
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build(&event_loop)
         .unwrap();
 
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor::default());
     let surface = instance.create_surface(&window)?;
 
     // Initialize GPU
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .expect("Request adapter");
 
         adapter
-            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .request_device(&wgpu::DeviceDescriptor::default())
             .await
             .expect("Request device")
     });
@@ -65,117 +65,120 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Render loop
     window.request_redraw();
 
-    event_loop.run(move |event, elwt| {
-        match event {
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::CloseRequested,
-                ..
-            } => elwt.exit(),
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::Resized(new_size),
-                ..
-            } => {
-                size = new_size;
+    event_loop
+        .run(move |event, elwt| {
+            match event {
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::CloseRequested,
+                    ..
+                } => elwt.exit(),
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::Resized(new_size),
+                    ..
+                } => {
+                    size = new_size;
 
-                surface.configure(
-                    &device,
-                    &wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: render_format,
-                        width: size.width,
-                        height: size.height,
-                        present_mode: wgpu::PresentMode::AutoVsync,
-                        alpha_mode: CompositeAlphaMode::Auto,
-                        view_formats: vec![render_format],
-                        desired_maximum_frame_latency: 2,
-                    },
-                );
-            }
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::RedrawRequested,
-                ..
-            } => {
-                // Get a command encoder for the current frame
-                let mut encoder = device.create_command_encoder(
-                    &wgpu::CommandEncoderDescriptor {
-                        label: Some("Redraw"),
-                    },
-                );
-
-                // Get the next frame
-                let frame =
-                    surface.get_current_texture().expect("Get next frame");
-                let view = &frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
-
-                // Clear frame
-                {
-                    let _ = encoder.begin_render_pass(
-                        &wgpu::RenderPassDescriptor {
-                            label: Some("Render pass"),
-                            color_attachments: &[Some(
-                                wgpu::RenderPassColorAttachment {
-                                    view,
-                                    resolve_target: None,
-                                    ops: wgpu::Operations {
-                                        load: wgpu::LoadOp::Clear(
-                                            wgpu::Color {
-                                                r: 0.4,
-                                                g: 0.4,
-                                                b: 0.4,
-                                                a: 1.0,
-                                            },
-                                        ),
-                                        store: wgpu::StoreOp::Store,
-                                    },
-                                },
-                            )],
-                            depth_stencil_attachment: None,
-                            timestamp_writes: None,
-                            occlusion_query_set: None,
+                    surface.configure(
+                        &device,
+                        &wgpu::SurfaceConfiguration {
+                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                            format: render_format,
+                            width: size.width,
+                            height: size.height,
+                            present_mode: wgpu::PresentMode::AutoVsync,
+                            alpha_mode: CompositeAlphaMode::Auto,
+                            view_formats: vec![render_format],
+                            desired_maximum_frame_latency: 2,
                         },
                     );
                 }
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::RedrawRequested,
+                    ..
+                } => {
+                    // Get a command encoder for the current frame
+                    let mut encoder = device.create_command_encoder(
+                        &wgpu::CommandEncoderDescriptor {
+                            label: Some("Redraw"),
+                        },
+                    );
 
-                glyph_brush.queue(Section {
-                    screen_position: (30.0, 30.0),
-                    bounds: (size.width as f32, size.height as f32),
-                    text: vec![Text::new("Hello wgpu_glyph!")
-                        .with_color([0.0, 0.0, 0.0, 1.0])
-                        .with_scale(40.0)],
-                    ..Section::default()
-                });
+                    // Get the next frame
+                    let frame =
+                        surface.get_current_texture().expect("Get next frame");
+                    let view = &frame
+                        .texture
+                        .create_view(&wgpu::TextureViewDescriptor::default());
 
-                glyph_brush.queue(Section {
-                    screen_position: (30.0, 90.0),
-                    bounds: (size.width as f32, size.height as f32),
-                    text: vec![Text::new("Hello wgpu_glyph!")
-                        .with_color([1.0, 1.0, 1.0, 1.0])
-                        .with_scale(40.0)],
-                    ..Section::default()
-                });
+                    // Clear frame
+                    {
+                        let _ = encoder.begin_render_pass(
+                            &wgpu::RenderPassDescriptor {
+                                label: Some("Render pass"),
+                                color_attachments: &[Some(
+                                    wgpu::RenderPassColorAttachment {
+                                        view,
+                                        resolve_target: None,
+                                        ops: wgpu::Operations {
+                                            load: wgpu::LoadOp::Clear(
+                                                wgpu::Color {
+                                                    r: 0.4,
+                                                    g: 0.4,
+                                                    b: 0.4,
+                                                    a: 1.0,
+                                                },
+                                            ),
+                                            store: wgpu::StoreOp::Store,
+                                        },
+                                        depth_slice: None,
+                                    },
+                                )],
+                                depth_stencil_attachment: None,
+                                timestamp_writes: None,
+                                occlusion_query_set: None,
+                            },
+                        );
+                    }
 
-                // Draw the text!
-                glyph_brush
-                    .draw_queued(
-                        &device,
-                        &mut staging_belt,
-                        &mut encoder,
-                        view,
-                        size.width,
-                        size.height,
-                    )
-                    .expect("Draw queued");
+                    glyph_brush.queue(Section {
+                        screen_position: (30.0, 30.0),
+                        bounds: (size.width as f32, size.height as f32),
+                        text: vec![Text::new("Hello wgpu_glyph!")
+                            .with_color([0.0, 0.0, 0.0, 1.0])
+                            .with_scale(40.0)],
+                        ..Section::default()
+                    });
 
-                // Submit the work!
-                staging_belt.finish();
-                queue.submit(Some(encoder.finish()));
-                frame.present();
-                // Recall unused staging buffers
-                staging_belt.recall();
+                    glyph_brush.queue(Section {
+                        screen_position: (30.0, 90.0),
+                        bounds: (size.width as f32, size.height as f32),
+                        text: vec![Text::new("Hello wgpu_glyph!")
+                            .with_color([1.0, 1.0, 1.0, 1.0])
+                            .with_scale(40.0)],
+                        ..Section::default()
+                    });
+
+                    // Draw the text!
+                    glyph_brush
+                        .draw_queued(
+                            &device,
+                            &mut staging_belt,
+                            &mut encoder,
+                            view,
+                            size.width,
+                            size.height,
+                        )
+                        .expect("Draw queued");
+
+                    // Submit the work!
+                    staging_belt.finish();
+                    queue.submit(Some(encoder.finish()));
+                    frame.present();
+                    // Recall unused staging buffers
+                    staging_belt.recall();
+                }
+                _ => {}
             }
-            _ => {}
-        }
-    }).map_err(Into::into)
+        })
+        .map_err(Into::into)
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -392,6 +392,7 @@ fn draw<D>(
                     load: wgpu::LoadOp::Load,
                     store: wgpu::StoreOp::Store,
                 },
+                depth_slice: None,
             })],
             depth_stencil_attachment,
             timestamp_writes: None,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -95,15 +95,15 @@ impl Cache {
 
         // TODO: Move to use Queue for less buffer usage
         encoder.copy_buffer_to_texture(
-            wgpu::ImageCopyBuffer {
+            wgpu::TexelCopyBufferInfo {
                 buffer: &self.upload_buffer,
-                layout: wgpu::ImageDataLayout {
+                layout: wgpu::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(padded_width as u32),
                     rows_per_image: Some(height as u32),
                 },
             },
-            wgpu::ImageCopyTexture {
+            wgpu::TexelCopyTextureInfo {
                 texture: &self.texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {


### PR DESCRIPTION
This upgrades the wgpu version from 23 to 26.
Only some minor changes were necessary.

Even though this crate is discontinued, it would be nice to be able to keep using it with recent versions of wgpu for projects that depend on it currently and don't want to move everything to glyphon yet.