### PR TITLE
Update to wgpu 28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wgpu_glyph"
 readme = "README.md"
 
 [dependencies]
-wgpu = "26"
+wgpu = "28"
 glyph_brush = "0.7"
 log = "0.4"
 

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 
     // Create staging belt
-    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
+    let mut staging_belt = wgpu::util::StagingBelt::new(device.clone(), 1024);
 
     // Prepare swap chain
     let render_format = wgpu::TextureFormat::Bgra8UnormSrgb;
@@ -136,6 +136,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 depth_stencil_attachment: None,
                                 timestamp_writes: None,
                                 occlusion_query_set: None,
+                                multiview_mask: None,
                             },
                         );
                     }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 
     // Create staging belt
-    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
+    let mut staging_belt = wgpu::util::StagingBelt::new(device.clone(), 1024);
 
     // Prepare swap chain and depth buffer
     let mut size = window.inner_size();
@@ -125,6 +125,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 depth_stencil_attachment: None,
                                 timestamp_writes: None,
                                 occlusion_query_set: None,
+                                multiview_mask: None,
                             },
                         );
                     }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 
     // Create staging belt
-    let mut staging_belt = wgpu::util::StagingBelt::new(1024);
+    let mut staging_belt = wgpu::util::StagingBelt::new(device.clone(), 1024);
 
     // Prepare swap chain
     let render_format = wgpu::TextureFormat::Bgra8UnormSrgb;
@@ -136,6 +136,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 depth_stencil_attachment: None,
                                 timestamp_writes: None,
                                 occlusion_query_set: None,
+                                multiview_mask: None,
                             },
                         );
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,6 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     ) -> Result<(), String> {
         self.process_queued(device, staging_belt, encoder);
         self.pipeline.draw(
-            device,
             staging_belt,
             encoder,
             target,
@@ -317,7 +316,6 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     ) -> Result<(), String> {
         self.process_queued(device, staging_belt, encoder);
         self.pipeline.draw(
-            device,
             staging_belt,
             encoder,
             target,
@@ -408,7 +406,6 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     ) -> Result<(), String> {
         self.process_queued(device, staging_belt, encoder);
         self.pipeline.draw(
-            device,
             staging_belt,
             encoder,
             target,
@@ -445,7 +442,6 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
         self.process_queued(device, staging_belt, encoder);
 
         self.pipeline.draw(
-            device,
             staging_belt,
             encoder,
             target,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -45,7 +45,6 @@ impl Pipeline<()> {
 
     pub fn draw(
         &mut self,
-        device: &wgpu::Device,
         staging_belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
@@ -54,7 +53,6 @@ impl Pipeline<()> {
     ) {
         draw(
             self,
-            device,
             staging_belt,
             encoder,
             target,
@@ -88,7 +86,6 @@ impl Pipeline<wgpu::DepthStencilState> {
 
     pub fn draw(
         &mut self,
-        device: &wgpu::Device,
         staging_belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
@@ -98,7 +95,6 @@ impl Pipeline<wgpu::DepthStencilState> {
     ) {
         draw(
             self,
-            device,
             staging_belt,
             encoder,
             target,
@@ -173,7 +169,6 @@ impl<Depth> Pipeline<Depth> {
                 &self.instances,
                 0,
                 size,
-                device,
             );
 
             instances_view.copy_from_slice(instances_bytes);
@@ -216,7 +211,7 @@ fn build<D>(
         address_mode_w: wgpu::AddressMode::ClampToEdge,
         mag_filter: filter_mode,
         min_filter: filter_mode,
-        mipmap_filter: filter_mode,
+        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
         ..Default::default()
     });
 
@@ -280,7 +275,7 @@ fn build<D>(
     let layout =
         device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
-            push_constant_ranges: &[],
+            immediate_size: 0,
             bind_group_layouts: &[&uniform_layout],
         });
 
@@ -340,7 +335,7 @@ fn build<D>(
             })],
             compilation_options: wgpu::PipelineCompilationOptions::default(),
         }),
-        multiview: None,
+        multiview_mask: None,
     });
 
     Pipeline {
@@ -360,7 +355,6 @@ fn build<D>(
 
 fn draw<D>(
     pipeline: &mut Pipeline<D>,
-    device: &wgpu::Device,
     staging_belt: &mut wgpu::util::StagingBelt,
     encoder: &mut wgpu::CommandEncoder,
     target: &wgpu::TextureView,
@@ -374,7 +368,6 @@ fn draw<D>(
             &pipeline.transform,
             0,
             unsafe { NonZeroU64::new_unchecked(16 * 4) },
-            device,
         );
 
         transform_view.copy_from_slice(bytemuck::cast_slice(&transform));
@@ -397,6 +390,7 @@ fn draw<D>(
             depth_stencil_attachment,
             timestamp_writes: None,
             occlusion_query_set: None,
+            multiview_mask: None,
         });
 
     render_pass.set_pipeline(&pipeline.raw);

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -85,7 +85,6 @@ impl Cache {
             &self.upload_buffer,
             0,
             NonZeroU64::new(padded_data_size).unwrap(),
-            device,
         );
 
         for row in 0..height {


### PR DESCRIPTION
Only boring changes required. There is only one notable thing: wgpu added a MipmapFilterMode so we couldn't use the `filter_mode` that can be configured via the public API. But this library never uses mip maps, so just hardcoding it to `Nearest` is valid.

---

I know this library is not actively developed anymore, but there are still some people using it and they would be happy to be able to update their wgpu :) 